### PR TITLE
Add platform flag to node image ref

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Node.js runtime as a base image
-FROM node:18
+FROM --platform=linux/x86_64 node:18
 # Set the working directory in the container
 WORKDIR /app
 


### PR DESCRIPTION
Add the --platform=linux/x86_64 to node base image ref as without building was failing on Mac. 